### PR TITLE
feat: Add basic activity feed API

### DIFF
--- a/activity_feed.js
+++ b/activity_feed.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a new activity feed endpoint with sample data.

### What changed?

Created a new `activity_feed.js` file that implements a simple Express server with a `/feed` endpoint. The endpoint returns mock activity data including user uploads, comments, and status updates.

### How to test?

1. Install dependencies: `npm install express`
2. Run the server: `node activity_feed.js`
3. Access the endpoint at `http://localhost:3000/feed`
4. Verify that the response contains the sample activity feed data in JSON format

### Why make this change?

This change provides a basic API endpoint for retrieving activity feed data, which will allow frontend components to display recent user activities. The implementation includes sample data to facilitate development and testing of the activity feed UI before integrating with actual user data.